### PR TITLE
Firefly GPS feature

### DIFF
--- a/urdf/firefly_base_gps.xacro
+++ b/urdf/firefly_base_gps.xacro
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!--
+  Copyright 2015 Fadri Furrer, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Michael Burri, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Mina Kamel, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Janosch Nikolic, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
+  Copyright 2015 Marija Popovic, ASL, ETH Zurich, Switzerland
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<robot name="firefly" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find rotors_description)/urdf/component_snippets.xacro" />
+  <!-- Instantiate firefly "mechanics" -->
+  <xacro:include filename="$(find rotors_description)/urdf/firefly.xacro" />
+
+  <!-- Specify reference parameters for GNSS receiver. -->
+  <xacro:property name="referenceLatitude" value="47.376247" />
+  <xacro:property name="referenceLongitude" value="8.546576" />
+  <xacro:property name="referenceHeading" value="0" />
+  <xacro:property name="referenceAltitude" value="0" />  
+
+  <!-- Instantiate a controller. -->
+  <xacro:controller_plugin_macro namespace="${namespace}" imu_sub_topic="imu" />
+
+  <!-- Mount an ADIS16448 IMU. -->
+  <xacro:default_imu namespace="${namespace}" parent_link="${namespace}/base_link" />
+
+  <!-- Mount a GNSS receiver. -->
+  <gazebo>
+    <plugin name="${namespace}_gps_sim" filename="libhector_gazebo_ros_gps.so">
+	<alwaysOn>true</alwaysOn>
+	<topicName>fix</topicName>
+	<velocityTopicName>fix_velocity</velocityTopicName>
+	<referenceLatitude>${referenceLatitude}</referenceLatitude>
+	<referenceLongitude>${referenceLongitude}</referenceLongitude>
+	<referenceHeading>${referenceHeading}</referenceHeading>
+	<referenceAltitude>${referenceAltitude}</referenceAltitude>
+    </plugin>
+  </gazebo>
+
+  <xacro:if value="$(arg enable_ground_truth)">
+    <xacro:ground_truth_imu_and_odometry namespace="${namespace}" parent_link="${namespace}/base_link" />
+  </xacro:if>
+
+  <xacro:if value="$(arg enable_logging)">
+    <!-- Instantiate a logger -->
+    <xacro:bag_plugin_macro
+      namespace="${namespace}"
+      bag_file="$(arg log_file)"
+      rotor_velocity_slowdown_sim="${rotor_velocity_slowdown_sim}" />
+  </xacro:if>
+
+</robot>


### PR DESCRIPTION
Moved pull request from rotors_simulator to here:
Added Firefly URDF file featuring the hectors GPS plugin in the new 'urdf' folder. This file is used in mav_control/path_publisher and could also be useful for some projects that need a GPS sensor for simulation. Note dependency on hector_gazebo_plugins.

@ffurrer 
